### PR TITLE
use python internal modules for gzip and bzip2

### DIFF
--- a/barman/backup.py
+++ b/barman/backup.py
@@ -720,10 +720,6 @@ class BackupManager(object):
             # At this point the original file has been removed
             wal_info.orig_filename = None
 
-            # Execute fsync() on the archived WAL file
-            file_fd = os.open(dst_file, os.O_RDONLY)
-            os.fsync(file_fd)
-            os.close(file_fd)
             # Execute fsync() on the archived WAL containing directory
             fsync_dir(dst_dir)
             # Execute fsync() also on the incoming directory

--- a/tests/test_compressor.py
+++ b/tests/test_compressor.py
@@ -120,8 +120,6 @@ class TestCompressor(object):
         assert compressor.compression == "dummy_compressor"
         assert compressor.debug is False
         assert compressor.remove_origin is False
-        assert compressor.compress is None
-        assert compressor.decompres is None
 
     def test_build_command(self):
         # prepare mock obj
@@ -156,9 +154,9 @@ class TestCustomCompressor(object):
                                       compression="custom")
 
         assert compressor is not None
-        assert compressor.compress.cmd == (
+        assert compressor._compress.cmd == (
             'command(){ dummy_compression_filter > "$2" < "$1";}; command')
-        assert compressor.decompress.cmd == (
+        assert compressor._decompress.cmd == (
             'command(){ dummy_decompression_filter > "$2" < "$1";}; command')
 
     def test_validate(self):


### PR DESCRIPTION
this avoids forking and shell execution, and simplifies
fsyncing of compressed files for these common compression
cases.