### PR TITLE
remove redundant sete[gu]id() calls

### DIFF
--- a/barman/utils.py
+++ b/barman/utils.py
@@ -49,8 +49,6 @@ def drop_privileges(user):
     os.setgroups(groups)
     os.setgid(pw.pw_gid)
     os.setuid(pw.pw_uid)
-    os.setegid(pw.pw_gid)
-    os.seteuid(pw.pw_uid)
     os.environ['HOME'] = pw.pw_dir
 
 

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -69,8 +69,6 @@ class TestDropPrivileges(object):
 
         os.setgid.assert_called_with(gid)
         os.setuid.assert_called_with(uid)
-        os.setegid.assert_called_with(gid)
-        os.seteuid.assert_called_with(uid)
         os.setgroups.assert_called_with(
             [_id for _id in groups if groups[_id]] + [gid])
         assert os.environ['HOME'] == home


### PR DESCRIPTION
Python's documentation of the os.setuid/os.setgid calls is
oversimplified to the point of being wrong. Under the hood,
the setuid(2)/setgid(2) functions are used, thus making these
calls as POSIX compliant as the underlying operating system.
As barman won't be installed SUID (it's an interpreter file),
effective, real and saved user id should always be the same.
That way, the only reason to use setuid() family calls at all
is for a privileged user (root) to change over to the barman
(unprivileged) user. According to POSIX.1-2013, the setuid()
call changes all three (real, effective and saved) uids if
called by a privileged user (the same holds for setgid() and
the group ids). In this construct, the additional seti[gu]id
calls are redundant no-ops and can be removed.