### PR TITLE
add native support for the pigz compressor

### DIFF
--- a/barman/compression.py
+++ b/barman/compression.py
@@ -143,6 +143,24 @@ class GZipCompressor(Compressor):
         self.decompress = self._build_command('gzip -c -d')
 
 
+class PigzCompressor(Compressor):
+    """
+    Predefined compressor with Pigz
+
+    Note that pigz on-disk is the same as gzip, so the MAGIC value of this
+    class is the same
+    """
+
+    MAGIC = b'\x1f\x8b\x08'
+
+    def __init__(self, config, compression, remove_origin=False, debug=False,
+                 path=None):
+        super(PigzCompressor, self).__init__(
+            config, compression, remove_origin, debug, path)
+        self.compress = self._build_command('pigz -c')
+        self.decompress = self._build_command('pigz -c -d')
+
+
 class BZip2Compressor(Compressor):
     """
     Predefined compressor with BZip2
@@ -182,6 +200,7 @@ class CustomCompressor(Compressor):
 #: to the class implementing it
 compression_registry = {
     'gzip': GZipCompressor,
+    'pigz': PigzCompressor,
     'bzip2': BZip2Compressor,
     'custom': CustomCompressor,
 }

--- a/doc/barman-tutorial.en.md
+++ b/doc/barman-tutorial.en.md
@@ -1019,6 +1019,7 @@ The `barman cron` command (see below) will compress WAL files if the
 allows three values:
 
 - `gzip`: for Gzip compression (requires gzip)
+- `pigz`: for Pigz compression (requires pigz)
 - `bzip2`: for Bzip2 compression (requires bzip2)
 - `custom`: for custom compression, which requires you to set the
   following options as well:

--- a/doc/barman.conf
+++ b/doc/barman.conf
@@ -16,7 +16,7 @@ barman_user = barman
 ; Log location
 log_file = /var/log/barman/barman.log
 
-; Default compression level: possible values are None (default), bzip2, gzip or custom
+; Default compression level: possible values are None (default), bzip2, gzip, pigz or custom
 ;compression = gzip
 
 ; Incremental backup support: possible values are None (default), link or copy


### PR DESCRIPTION
The same result achieved by this commit can be achieved, using today's barman, specifying custom (de)compressor filters. And it works just fine.

But in write-intense workloads (been there, done that) the difference between workloads might be relevant enough (it's up to you to judge, of course) to justify having *native* pigz support rather then requiring user to customize it using filter.