### PR TITLE
Added the -p flag to recursively add parent directories that do not exist

### DIFF
--- a/barman/fs.py
+++ b/barman/fs.py
@@ -73,7 +73,7 @@ class UnixLocalCommand(object):
             else:
                 return False
         else:
-            mkdir_ret = self.cmd('mkdir %s' % dir_path)
+            mkdir_ret = self.cmd('mkdir -p %s' % dir_path)
             if mkdir_ret == 0:
                 return True
             else:


### PR DESCRIPTION
I added the -p flag to resolve the issue when restoring and I have tablespaces two levels deep. For example here is a failure:

```
EXCEPTION: unable to prepare 'drupal_dbspace' tablespace (destination '/usr/local/pgsql/data/tablespaces/drupal_dbspace'): mkdir execution failed
```

In the above case the table space lives under `/usr/local/pgsql/data/tablespaces`. Currently Barman does not support this.

Adding the `-p` allows for the parent directories to be created. In my test case it created the tablespaces correctly
```
Destination directory: /usr/local/pgsql/data
        27837, drupal_dbspace, /usr/local/pgsql/data/tablespaces/drupal_dbspace
        27838, drupal_indexspace, /usr/local/pgsql/data/tablespaces/drupal_indexspace
        27839, drupal_zlog_dbspace, /usr/local/pgsql/data/tablespaces/drupal_zlog_dbspace
Copying the base backup.
```