### PR TITLE
mark "failed backups" check as non-fatal

### DIFF
--- a/barman/server.py
+++ b/barman/server.py
@@ -65,7 +65,8 @@ class CheckStrategy(object):
 
     # Default list used as a filter to identify non-critical checks
     NON_CRITICAL_CHECKS = ['minimum redundancy requirements',
-                           'backup maximum age', 'archiver errors']
+                           'backup maximum age', 'failed backups',
+                           'archiver errors']
 
     def __init__(self, ignore_checks=NON_CRITICAL_CHECKS):
         """


### PR DESCRIPTION
allows taking a backup when the previous backup has failed

After one failed backup, further backups are denied with message
barman.server ERROR: Check 'failed backups' failed for server '<server>'
That's not helpful, as I'd rather take a fresh backup soon after the process failed for some reason (e.g. network issues, server down, ...)