### PR TITLE
unbreak backups when archive_mode is "always"

### DIFF
--- a/barman/postgres.py
+++ b/barman/postgres.py
@@ -378,7 +378,9 @@ class PostgreSQLConnection(PostgreSQL):
             # also evaluating if the server is archiving without issues
             # and the archived WALs per second rate
             cur.execute(
-                "SELECT *, current_setting('archive_mode')::BOOLEAN "
+                "SELECT *, "
+                "CASE current_setting('archive_mode') "
+                "  WHEN 'off' THEN 'f'::BOOLEAN ELSE 't'::BOOLEAN END "
                 "AND (last_failed_wal IS NULL "
                 "OR last_failed_wal LIKE '%.history' "
                 "AND substring(last_failed_wal from 1 for 8) "

--- a/tests/test_postgres.py
+++ b/tests/test_postgres.py
@@ -380,7 +380,9 @@ class TestPostgres(object):
         assert server.postgres.get_archiver_stats() == {'a': 'b'}
         # check for the correct call on the execute method
         cursor_mock.execute.assert_called_once_with(
-            "SELECT *, current_setting('archive_mode')::BOOLEAN "
+            "SELECT *, "
+            "CASE current_setting('archive_mode') "
+            "  WHEN 'off' THEN 'f'::BOOLEAN ELSE 't'::BOOLEAN END "
             "AND (last_failed_wal IS NULL "
             "OR last_failed_wal LIKE '%.history' "
             "AND substring(last_failed_wal from 1 for 8) "


### PR DESCRIPTION
cannot cast 'always' to BOOLEAN, this will break the whole chain.
the error handling here needs some attention, too

The query in question tried to read the archive_mode setting into a boolean variable by casting it as a BOOLEAN in the first place. While being a nice trick, this is not safe: archive_mode is not a boolean parameter anymore in 9.5.

Errors from the database connection are only logged at DEBUG level and then ignored, but as psycopg does not use autocommit by default (as it would be the sane thing to do) all later statements will ERROR out. I haven't checked yet if it's safe to force autocommit here.