### PR TITLE
Split the connstring on whitespaces intead of one space

### DIFF
--- a/barman/postgres.py
+++ b/barman/postgres.py
@@ -93,7 +93,7 @@ class PostgreSQL(with_metaclass(ABCMeta, RemoteStatusMixin)):
         :rtype: dict[str,str]
         """
         # TODO: this might be made more robust in the future
-        return dict(x.split('=', 1) for x in dsn.split(' '))
+        return dict(x.split('=', 1) for x in dsn.split())
 
     def get_connection_string(self, application_name=None):
         """


### PR DESCRIPTION
With `.split(' ')`, the connstring can't contain multiple spaces or tab between the arguments.
Therefore, Barman does not consider `host=localhost  port=5432` as valid.

The postgresql libraries do accept multiple whitespaces between parameters, so passing `"host=localhost\tport=5432      user=postgres"` is valid.

Using `.split()` will not reject valid conninfo string.
