### PR TITLE
force the datestyle to iso for replication connections

### DIFF
--- a/barman/postgres.py
+++ b/barman/postgres.py
@@ -234,6 +234,9 @@ class StreamingConnection(PostgreSQL):
         # Make sure we connect using the 'replication' option which
         # triggers streaming replication protocol communication
         self.conn_parameters['replication'] = 'true'
+        # ensure that the datestyle is set to iso, working around an
+        # issue in some psycopg2 versions
+        self.conn_parameters['options'] = '-cdatestyle=iso'
         # Override 'dbname' parameter. This operation is required to mimic
         # the behaviour of pg_receivexlog and pg_basebackup
         self.conn_parameters['dbname'] = 'replication'

--- a/tests/test_postgres.py
+++ b/tests/test_postgres.py
@@ -1233,7 +1233,9 @@ class TestStreamingConnection(object):
                                   'dbname=test_db'})
         assert server.streaming.conn_parameters['dbname'] == 'replication'
         assert server.streaming.conninfo == 'dbname=replication ' \
-                                            'host=/test port=5496 ' \
+                                            'host=/test ' \
+                                            'options=-cdatestyle=iso ' \
+                                            'port=5496 ' \
                                             'replication=true ' \
                                             'user=test'
 


### PR DESCRIPTION
this works around a bug in some psycopg2 versions
reference: https://github.com/psycopg/psycopg2/pull/482