### PR TITLE
Clarifications on `cron` command in docs

### DIFF
--- a/doc/manual/41-global-commands.en.md
+++ b/doc/manual/41-global-commands.en.md
@@ -15,6 +15,11 @@ The following list includes the general commands.
 
 ## `cron`
 
+`barman` doesn't include a long-running daemon or service file (there's
+nothing to `systemctl start`, `service start`, etc.).  Instead, the `barman
+cron` subcommand is provided to perform `barman`'s background
+"steady-state" backup operations.
+
 You can perform maintenance operations, on both WAL files and backups,
 using the `cron` command:
 

--- a/doc/manual/41-global-commands.en.md
+++ b/doc/manual/41-global-commands.en.md
@@ -44,6 +44,15 @@ The `cron` command ensures that WAL streaming is started for those
 servers that have requested it, by transparently executing the
 `receive-wal` command.
 
+In order to stop the operations started by the `cron` command, comment out
+the cron entry and execute:
+
+```bash
+barman receive-wal --stop SERVER_NAME
+```
+
+You might want to check `barman list-server` to make sure you get all of
+your servers.
 
 ## `diagnose`
 


### PR DESCRIPTION
It can be a bit surprising to discover that barman doesn't have any sort of
daemon program, as many long-running services do.  Make this clear up front
to avoid confusion.

Also, it's not immediately clear from the docs how to stop all of the processes
that get started by the `cron` command.  Add some instructions to the
section on `cron` documenting how to stop things properly.
