### PR TITLE
Fix for #111

### DIFF
--- a/barman/postgres.py
+++ b/barman/postgres.py
@@ -1313,6 +1313,8 @@ class PostgreSQLConnection(PostgreSQL):
         else:
             synchronous_standby_names = (
                 self.get_setting('synchronous_standby_names'))
+            if synchronous_standby_names is None:
+                return []
             # Normalise the list of sync standby names
             # On PostgreSQL 9.6 it is possible to specify the number of
             # required synchronous standby using this format:


### PR DESCRIPTION
postgres.get_setting() returns None on error.   This fix catches it and returns the appropriate empty list