### PR TITLE
Add --wal-method option to pg_basebackup ver>=10.

### DIFF
--- a/barman/command_wrappers.py
+++ b/barman/command_wrappers.py
@@ -881,11 +881,12 @@ class PgBaseBackup(PostgreSQLClient):
         self.args += ['-v', '--no-password', '--pgdata=%s' % destination]
 
         if version and version >= Version("10"):
-            # If version of the client is >= 10 it would use
-            # a temporary replication slot by default to keep WALs.
+            # If version of the client is >= 10 it would use an additional wal
+            # sender and a temporary replication slot by default to keep WALs.
             # We don't need it because Barman already stores the full
-            # WAL stream, so we disable this feature to avoid wasting one slot.
-            self.args += ['--no-slot']
+            # WAL stream, so we disable this feature to avoid wasting one slot
+            # and wal sender process.
+            self.args += ['--no-slot', '--wal-method=none']
 
         # The tablespace mapping option is repeated once for each tablespace
         if tbs_mapping:

--- a/tests/test_command_wrappers.py
+++ b/tests/test_command_wrappers.py
@@ -940,10 +940,10 @@ class TestPgBaseBackup(object):
         assert pg_basebackup.err_handler
         assert pg_basebackup.out_handler
 
-    def test_no_slot(self):
+    def test_version_10(self):
         """
-        Test that --no-slot option is correctly passed if the pg_basebakup
-        client is version >= 10
+        Test that --no-slot and --wal-method options are correctly passed
+        if the pg_basebakup client is version >= 10
         """
         connection_mock = mock.MagicMock()
         connection_mock.get_connection_string.return_value = 'test_connstring'
@@ -959,6 +959,7 @@ class TestPgBaseBackup(object):
             "--no-password",
             "--pgdata=/dest/dir",
             "--no-slot",
+            "--wal-method=none",
             "a",
             "b",
         ]


### PR DESCRIPTION
By default pg_basebackup 10 launch additional wal sender process to include
all WAL generated during backup into the base bakcup.
Because Barman already stores full WAL stream we don't need it.