### PR TITLE
Fixed UnicodeEncodeError

### DIFF
--- a/barman/cli.py
+++ b/barman/cli.py
@@ -1081,6 +1081,11 @@ def main():
     """
     The main method of Barman
     """
+    try:
+        reload(sys)
+        sys.setdefaultencoding('utf8')
+    except:
+        pass
     p = ArghParser(epilog='Barman by 2ndQuadrant (www.2ndQuadrant.com)')
     p.add_argument('-v', '--version', action='version',
                    version='%s\n\nBarman by 2ndQuadrant (www.2ndQuadrant.com)'


### PR DESCRIPTION
Report by Daymel Bonne, from a list of users in Spanish:

```
Traceback (most recent call last):
  File "/usr/lib/python2.7/site-packages/barman/cli.py", line 1123, in main
    p.dispatch(pre_call=global_config)
  File "/usr/lib/python2.7/site-packages/argh/helpers.py", line 55, in dispatch
    return dispatch(self, *args, **kwargs)
  File "/usr/lib/python2.7/site-packages/argh/dispatching.py", line 174, in dispatch
    for line in lines:
  File "/usr/lib/python2.7/site-packages/argh/dispatching.py", line 277, in _execute_command
    for line in result:
  File "/usr/lib/python2.7/site-packages/argh/dispatching.py", line 231, in _call
    result = function(namespace_obj)
  File "/usr/lib/python2.7/site-packages/barman/cli.py", line 215, in backup
    server.backup()
  File "/usr/lib/python2.7/site-packages/barman/server.py", line 989, in backup
    self.backup_manager.backup()
  File "/usr/lib/python2.7/site-packages/barman/backup.py", line 369, in backup
    msg_lines = str(e).strip().splitlines()
UnicodeEncodeError: 'ascii' codec can't encode character u'\xab' in position 455: ordinal not in range(128)

2018-04-27 11:49:02,101 [17847] barman.config DEBUG: Including configuration file: vm-latin1.cx.ar.conf
2018-04-27 11:49:02,101 [17845] barman.config DEBUG: Including configuration file: latin1.cx.ar.conf
2018-04-27 11:49:02,102 [17847] barman.cli DEBUG: Initialised Barman version 2.3 (config: /etc/barman.conf, args: {'debug': False, 'command': 'cron', 'quiet': True, 'format': 'console'})
```