### PR TITLE
Recovery Retry Script doesn't get passed the recovery environment

### DIFF
--- a/barman/backup.py
+++ b/barman/backup.py
@@ -518,7 +518,7 @@ class BackupManager(RemoteStatusMixin):
         # Run the pre_recovery_retry_script if present.
         retry_script = RetryHookScriptRunner(
             self, 'recovery_retry_script', 'pre')
-        script.env_from_recover(backup_info, dest, tablespaces, remote_command,
+        retry_script.env_from_recover(backup_info, dest, tablespaces, remote_command,
                                 **kwargs)
         retry_script.run()
 
@@ -535,7 +535,7 @@ class BackupManager(RemoteStatusMixin):
         try:
             retry_script = RetryHookScriptRunner(
                 self, 'recovery_retry_script', 'post')
-            script.env_from_recover(
+            retry_script.env_from_recover(
                 backup_info, dest, tablespaces, remote_command, **kwargs)
             retry_script.run()
         except AbortedRetryHookScript as e:


### PR DESCRIPTION
The current recovery retry script doesn't get passed the recovery environment due to a typo in backup.py, it's reapplying the environment to the original recovery_script's "script" variable, rather than the "retry_script" variable.

I'm creating a pull request to resolve, but this seems a pretty straightforward bug.
