### PR TITLE
Improve performance of date parsing

### DIFF
--- a/barman/copy_controller.py
+++ b/barman/copy_controller.py
@@ -948,7 +948,7 @@ class RsyncCopyController(object):
         # Cache and reuse datetime parsing objects for speed
         tzlocal = dateutil.tz.tzlocal()
         default = datetime.datetime.now().replace(hour=0, minute=0, second=0,
-                                                  microsecond=0, 
+                                                  microsecond=0,
                                                   tzinfo=tzlocal)
         for line in rsync.out.splitlines():
             line = line.rstrip()

--- a/barman/copy_controller.py
+++ b/barman/copy_controller.py
@@ -946,8 +946,10 @@ class RsyncCopyController(object):
         rsync.get_output('--no-human-readable', '--list-only', '-r', path,
                          check=True)
         # Cache and reuse datetime parsing objects for speed
-        tzlocal=dateutil.tz.tzlocal()
-        default = datetime.datetime.now().replace(hour=0, minute=0, second=0, microsecond=0,tzinfo=tzlocal)
+        tzlocal = dateutil.tz.tzlocal()
+        default = datetime.datetime.now().replace(hour=0, minute=0, second=0,
+                                                  microsecond=0, 
+                                                  tzinfo=tzlocal)
         for line in rsync.out.splitlines():
             line = line.rstrip()
             match = self.LIST_ONLY_RE.match(line)
@@ -956,7 +958,8 @@ class RsyncCopyController(object):
                 # no exceptions here: the regexp forces 'size' to be an integer
                 size = int(match.group('size'))
                 try:
-                    date = dateutil.parser.parse(match.group('date'),default=default)
+                    date = dateutil.parser.parse(match.group('date'),
+                                                 default=default)
                     date = date.replace(tzinfo=tzlocal)
                 except (TypeError, ValueError):
                     # This should not happen, due to the regexp


### PR DESCRIPTION
Looking up the local timezone once for each src file, and not using
a default object for dateutil.parser.parse both lead to redundant
system calls.  This creates a small but noticable slowdown when
backing up a cluster with a very large number of unchanged files.