### PR TITLE
Remove spurious message when resetting WAL

### DIFF
--- a/barman/server.py
+++ b/barman/server.py
@@ -1960,7 +1960,8 @@ class Server(RemoteStatusMixin):
                          "barman configuration file")
             return
 
-        output.info("Starting receive-wal for server %s", self.config.name)
+        if not reset:
+            output.info("Starting receive-wal for server %s", self.config.name)
         try:
             # Take care of the receive-wal lock.
             # Only one receiving process per server is permitted


### PR DESCRIPTION
When calling "barman receive-wal --reset foo", it gives
a message:

Starting receive-wal for server foo

However, it does not actually attempt to start the receive-wal
process when called with --reset.