### PR TITLE
Fix "Backup completed" elapsed time

### DIFF
--- a/barman/backup.py
+++ b/barman/backup.py
@@ -447,7 +447,7 @@ class BackupManager(RemoteStatusMixin):
                 "Backup completed (start time: %s, elapsed time: %s)",
                 self.executor.copy_start_time,
                 human_readable_timedelta(
-                    executor.copy_end_time - executor.copy_start_time))
+                    datetime.datetime.now() - executor.copy_start_time))
             # Create a restore point after a backup
             target_name = 'barman_%s' % backup_info.backup_id
             self.server.postgres.create_restore_point(target_name)


### PR DESCRIPTION
The message issued when a backup completes does not include
all of the elapsed time, but rather only a non-intuitive
subset of it. Notably it does not include the time taken
to fsync all of the files, which can be substantial. Make
the message include all time up to when the message is
issued.