### PR TITLE
Fix exclude_and_protect_filter

### DIFF
--- a/barman/copy_controller.py
+++ b/barman/copy_controller.py
@@ -851,8 +851,8 @@ class RsyncCopyController(object):
 
             # Add every file in the source path to the list of files
             # to be protected from deletion ('exclude_and_protect.filter')
-            exclude_and_protect_filter.write('P ' + entry.path + '\n')
-            exclude_and_protect_filter.write('- ' + entry.path + '\n')
+            exclude_and_protect_filter.write('P /' + entry.path + '\n')
+            exclude_and_protect_filter.write('- /' + entry.path + '\n')
 
             # If source item is older than safe_horizon,
             # add it to 'safe.list'

--- a/tests/test_copy_controller.py
+++ b/tests/test_copy_controller.py
@@ -566,16 +566,16 @@ class TestRsyncCopyController(object):
         # the files in the source
         assert item.exclude_and_protect_file
         assert open(item.exclude_and_protect_file).read() == (
-            'P tmp/safe\n'
-            '- tmp/safe\n'
-            'P tmp/check\n'
-            '- tmp/check\n'
-            'P tmp/diff_time\n'
-            '- tmp/diff_time\n'
-            'P tmp/diff_size\n'
-            '- tmp/diff_size\n'
-            'P tmp/new\n'
-            '- tmp/new\n'
+            'P /tmp/safe\n'
+            '- /tmp/safe\n'
+            'P /tmp/check\n'
+            '- /tmp/check\n'
+            'P /tmp/diff_time\n'
+            '- /tmp/diff_time\n'
+            'P /tmp/diff_size\n'
+            '- /tmp/diff_size\n'
+            'P /tmp/new\n'
+            '- /tmp/new\n'
         )
         # The check list must contain identical files after the safe_horizon
         assert len(item.check_list) == 1


### PR DESCRIPTION
Filters which do not start with '/' are treated as wildcards.
For the exclude_and_protect_filter, this is both slow and
incorrect. For example, if there were a spurious file named
"pg_xact/0000" somewhere other than the top-level dest data
directory, the unachored protect filter means it would not
get deleted.  With an anchored protect filter, it will get
deleted, as it should.

So fix this by prefixing the filter paths with a '/'.

The bug fix is minor (it is not clear why such spurious files
would exist in the first place) but the speed-up should be
appreciated by anyone with a large number of files in their
database.