### PR TITLE
Fixed get-wal on Python 3 by reading/writing bytes instead of utf-8

### DIFF
--- a/barman/server.py
+++ b/barman/server.py
@@ -1509,8 +1509,12 @@ class Server(RemoteStatusMixin):
                 source_file = compressed_file.name
 
         # Copy the prepared source file to destination
-        with open(source_file) as input_file:
-            shutil.copyfileobj(input_file, destination)
+        if hasattr(destination, 'buffer'):
+            with open(source_file, 'rb') as input_file:
+                shutil.copyfileobj(input_file, destination.buffer)
+        else:
+            with open(source_file) as input_file:
+                shutil.copyfileobj(input_file, destination)
 
         # Remove temp files
         if uncompressed_file is not None:


### PR DESCRIPTION
When using Python 3 the `get-wal` command can fail with a `UnicodeDecodeError` because it tries to parse the binary data as UTF-8.

```python
Traceback (most recent call last):
  File "/usr/local/lib/python3.6/site-packages/barman/cli.py", line 1329, in main
    p.dispatch(pre_call=global_config)
  File "/usr/local/lib/python3.6/site-packages/argh/helpers.py", line 55, in dispatch
    return dispatch(self, *args, **kwargs)
  File "/usr/local/lib/python3.6/site-packages/argh/dispatching.py", line 174, in dispatch
    for line in lines:
  File "/usr/local/lib/python3.6/site-packages/argh/dispatching.py", line 277, in _execute_command
    for line in result:
  File "/usr/local/lib/python3.6/site-packages/argh/dispatching.py", line 231, in _call
    result = function(namespace_obj)
  File "/usr/local/lib/python3.6/site-packages/barman/cli.py", line 866, in get_wal
    peek=peek)
  File "/usr/local/lib/python3.6/site-packages/barman/server.py", line 1513, in get_wal
    shutil.copyfileobj(input_file, destination)
  File "/usr/local/lib/python3.6/shutil.py", line 79, in copyfileobj
    buf = fsrc.read(length)
  File "/usr/local/lib/python3.6/codecs.py", line 321, in decode
    (result, consumed) = self._buffer_decode(data, self.errors, final)
UnicodeDecodeError: 'utf-8' codec can't decode byte 0x98 in position 0: invalid start byte
```

This works around that issue by writing straight to the buffer an reading as binary. In all other cases this behaves as before (which might still be broken, I haven't encountered those errors).