### PR TITLE
enable python3 for bash completion

### DIFF
--- a/scripts/barman.bash_completion
+++ b/scripts/barman.bash_completion
@@ -1,1 +1,1 @@
-eval "$(register-python-argcomplete barman)"
+eval "$( ( register-python-argcomplete3 barman || register-python-argcomplete barman ) 2>/dev/null )"


### PR DESCRIPTION
This modified bash completion snippet should work for Python3 (preferred, if installed) and Python2 (as a fallback)