### PR TITLE
Add JSON Output Writer

### DIFF
--- a/TODO
+++ b/TODO
@@ -12,7 +12,6 @@ Copyright (C) 2011-2019 2ndQuadrant Limited
 * Logical backup integration (pg_dump on sandbox instances)
 * WAL retention policies
 * Grandfather-Father-Son backup
-* JSON output for full automation
 * Deep Backup validation
 * SSH only connections
 * ...

--- a/barman/output.py
+++ b/barman/output.py
@@ -1088,7 +1088,7 @@ class JsonOutputWriter(object):
             message = json.loads(message)
             self.json_output = message
             self.close()
-        except json.decoder.JSONDecodeError:
+        except ValueError:
             pass
 
         if '_INFO' not in self.json_output:
@@ -1212,7 +1212,7 @@ class JsonOutputWriter(object):
 
         self.json_output.update(dict(
             recovery_start_time=results['recovery_start_time'].isoformat(sep=' '),
-            recovery_start_time_timestamp=results['recovery_start_time'].timestamp(),
+            recovery_start_time_timestamp=results['recovery_start_time'].strftime('%s'),
             recovery_elapsed_time=human_readable_timedelta(datetime.datetime.now() - results['recovery_start_time']),
             recovery_elapsed_time_seconds=(datetime.datetime.now() - results['recovery_start_time']).total_seconds()
         ))
@@ -1301,7 +1301,7 @@ class JsonOutputWriter(object):
 
         if backup_info.status in BackupInfo.STATUS_COPY_DONE:
             output.update(dict(
-                end_time_timestamp=backup_info.end_time.timestamp(),
+                end_time_timestamp=backup_info.end_time.strftime('%s'),
                 end_time=backup_info.end_time.ctime(),
                 size_bytes=backup_size,
                 wal_size_bytes=wal_size,
@@ -1378,9 +1378,9 @@ class JsonOutputWriter(object):
                     wal_compression_ratio='{percent:.2%}'.format(percent=data['wal_compression_ratio'])
                 ))
             self.json_output[server_name]['base_backup_information'].update(dict(
-                begin_time_timestamp=data['begin_time'].timestamp(),
+                begin_time_timestamp=data['begin_time'].strftime('%s'),
                 begin_time=data['begin_time'].isoformat(sep=' '),
-                end_time_timestamp=data['end_time'].timestamp(),
+                end_time_timestamp=data['end_time'].strftime('%s'),
                 end_time=data['end_time'].isoformat(sep=' ')
             ))
             copy_stats = data.get('copy_stats')

--- a/tests/testing_helpers.py
+++ b/tests/testing_helpers.py
@@ -404,6 +404,12 @@ def parse_recovery_conf(recovery_conf_file):
     return recovery_conf
 
 
+def find_by_attr(list, attr, value):
+  for element in list:
+    if element[attr] == value:
+      return element
+
+
 # The following two functions are useful to create bytes/unicode strings
 # in Python 2 and in Python 3 with the same syntax.
 if sys.version_info[0] >= 3:

--- a/tests/testing_helpers.py
+++ b/tests/testing_helpers.py
@@ -405,9 +405,9 @@ def parse_recovery_conf(recovery_conf_file):
 
 
 def find_by_attr(list, attr, value):
-  for element in list:
-    if element[attr] == value:
-      return element
+    for element in list:
+        if element[attr] == value:
+            return element
 
 
 # The following two functions are useful to create bytes/unicode strings


### PR DESCRIPTION
This PR adds `JsonOutputWriter` class (and tests) for JSON output support. It has been in TODO for 6 years and I just needed it now.

JSON output adds couple of additional fields using suffixes like `_seconds`, `_bytes`, `_timestamp` to store raw data for easier processing. Original values (human-readable) are stored without suffix. I tried to be compatible with `ConsoleOutputWriter` as much as possible to the point that some parts of code are aligned for easier maintenance.

Motivation for this was to get computer-readable barman's output without parsing console output or getting into details how Barman's internals work. Turns out it is not that straightforward to list backups or show server checks. With JSON output one's would want to use this one liner:

```status = json.loads(subprocess.run(['barman', '-f', 'json', 'status', server_name], stdout=subprocess.PIPE).stdout)```

Some examples what JSON output looks like:

```
$ barman -f json status postgres01 | jq .
{
  "postgres01": {
    "description": "Barman postgres01 streaming backup",
    "active": true,
    "disabled": false,
    "postgresql_version": "11.4",
    "cluster_state": "in production",
    "pgespresso_extension": "Not available",
    "current_data_size": "23.1 MiB",
    "postgresql_data_directory": "/var/lib/postgresql/11/main",
    "current_wal_segment": "000000010000000000000003",
    "passive_node": false,
    "retention_policies": "enforced (mode: auto, retention: REDUNDANCY 8, WAL retention: MAIN)",
    "no_of_available_backups": 0,
    "first_available_backup": null,
    "last_available_backup": null,
    "minimum_redundancy_requirements": "FAILED (0/3)"
  }
}
```

```
$ barman -f json status unknown | jq .
{
  "_ERROR": [
    "Unknown server 'unknown'"
  ]
}
```

```
$ barman -f json list-backup other | jq .
{
  "other": [
    {
      "backup_id": "20190711T000502",
      "end_time_timestamp": 1562811132.038145,
      "end_time": "Thu Jul 11 04:12:12 2019",
      "size_bytes": 1483735533992,
      "wal_size_bytes": 70817633687,
      "size": "1.3 TiB",
      "wal_size": "66.0 GiB",
      "status": "DONE",
      "retention_status": "-",
      "tablespaces": []
    },
    {
      "backup_id": "20190708T000502",
      "end_time_timestamp": 1562551763.394178,
      "end_time": "Mon Jul  8 04:09:23 2019",
      "size_bytes": 1475780242798,
      "wal_size_bytes": 447323712367,
      "size": "1.3 TiB",
      "wal_size": "416.6 GiB",
      "status": "DONE",
      "retention_status": "-",
      "tablespaces": []
    },
    [...]
  ]
}
```

```
$ barman -f json check admin | jq .
{
  "admin": {
    "postgresql": {
      "status": "FAILED",
      "hint": ""
    },
    "failed_backups": {
      "status": "OK",
      "hint": "there are 0 failed backups"
    },
    "receive_wal_running": {
    "status": "FAILED",
    "hint": "See the Barman log file for more details"
    }
  [...]
  }
}
```