### PR TITLE
Log formatting tweak for consistency

### DIFF
--- a/barman/server.py
+++ b/barman/server.py
@@ -117,7 +117,7 @@ class CheckStrategy(object):
         :param str check_name: the name of the check that is starting
         """
         self.running_check = check_name
-        _logger.debug("Starting check: %s" % check_name)
+        _logger.debug("Starting check: '%s'" % check_name)
 
     def _check_name(self, check):
         if not check:


### PR DESCRIPTION
Consider following log output:

    2019-08-09 12:22:35,199 [4365] barman.server DEBUG: Check 'archive_command' succeeded for server 'test_cluster'
    2019-08-09 12:22:35,199 [4365] barman.server DEBUG: Check 'continuous archiving' succeeded for server 'test_cluster'
    2019-08-09 12:22:35,199 [4365] barman.server DEBUG: Starting check: archiver errors
    2019-08-09 12:22:35,199 [4365] barman.server DEBUG: Check 'archiver errors' succeeded for server 'test_cluster'

At first glance this entry:

    "Starting check: archiver errors"

sounded like "Starting check" was reporting an error.

Patch changes the "Starting check" log output to enclose the check name in single quotes, which is consistent with the following "Check '...' succeeded" log output.