### PR TITLE
Fixed bug, enviroment variables not set in wal delete retry scripts.

### DIFF
--- a/barman/backup.py
+++ b/barman/backup.py
@@ -645,7 +645,7 @@ class BackupManager(RemoteStatusMixin):
         # Run the pre_wal_delete_retry_script if present.
         retry_script = RetryHookScriptRunner(
             self, 'wal_delete_retry_script', 'pre')
-        script.env_from_wal_info(wal_info)
+        retry_script.env_from_wal_info(wal_info)
         retry_script.run()
 
         error = None
@@ -667,7 +667,7 @@ class BackupManager(RemoteStatusMixin):
         try:
             retry_script = RetryHookScriptRunner(
                 self, 'wal_delete_retry_script', 'post')
-            script.env_from_wal_info(wal_info, None, error)
+            retry_script.env_from_wal_info(wal_info, None, error)
             retry_script.run()
         except AbortedRetryHookScript as e:
             # Ignore the ABORT_STOP as it is a post-hook operation

--- a/barman/backup.py
+++ b/barman/backup.py
@@ -638,7 +638,7 @@ class BackupManager(RemoteStatusMixin):
         """
 
         # Run the pre_wal_delete_script if present.
-        script = HookScriptRunner(self, 'wal_delete', 'pre')
+        script = HookScriptRunner(self, 'wal_delete_script', 'pre')
         script.env_from_wal_info(wal_info)
         script.run()
 
@@ -677,7 +677,7 @@ class BackupManager(RemoteStatusMixin):
                             e.hook.exit_status, e.hook.script)
 
         # Run the post_wal_delete_script if present.
-        script = HookScriptRunner(self, 'wal_delete', 'post')
+        script = HookScriptRunner(self, 'wal_delete_script', 'post')
         script.env_from_wal_info(wal_info, None, error)
         script.run()
 


### PR DESCRIPTION
Bugfix related to enviroment variables in hook scripts similar to this one: [#203 ](https://github.com/2ndquadrant-it/barman/pull/203) . It concerns pre and post wal delete retry scripts.