### PR TITLE
Remove strict superuser requirement for PG 10+

### DIFF
--- a/barman/exceptions.py
+++ b/barman/exceptions.py
@@ -240,6 +240,12 @@ class PostgresSuperuserRequired(PostgresException):
     """
 
 
+class PostgresSuperuserOrBackupFunctionsAccessRequired(PostgresException):
+    """
+    Superuser or pg_start_backup(), pg_switch_wal(), ... etc access is required
+    """
+
+
 class PostgresIsInRecovery(PostgresException):
     """
     PostgreSQL is in recovery, so no write operations are allowed

--- a/barman/server.py
+++ b/barman/server.py
@@ -661,18 +661,18 @@ class Server(RemoteStatusMixin):
         else:
             check_strategy.result(self.config.name, False)
             return
-        # Check for superuser privileges in PostgreSQL
-        if remote_status.get('is_superuser') is not None:
-            check_strategy.init_check('is_superuser')
-            if remote_status.get('is_superuser'):
+
+        # Check for superuser privileges or privileges needed to perform backups
+        if remote_status.get('is_superuser') is not None and remote_status.get('is_backup_eligible') is not None:
+            check_strategy.init_check('superuser rights or grants to replication / backup functions')
+            if remote_status.get('is_superuser') or remote_status.get('is_backup_eligible'):
                 check_strategy.result(
                     self.config.name, True)
             else:
                 check_strategy.result(
                     self.config.name, False,
-                    hint='superuser privileges for PostgreSQL '
-                         'connection required',
-                    check='not superuser'
+                    hint='superuser or individual privileges to backup functions required',
+                    check='not superuser nor no access to functions needed for backups'
                 )
 
         if 'streaming_supported' in remote_status:


### PR DESCRIPTION
For some time already it's possible to pull backups without superuser -
which is actually very desired for security sensitive environments.
Non-superuser backups need quite some roles / grants though - this is
documented now in the 21-preliminary_steps.en.md doc.